### PR TITLE
feat: change processing from markdown to html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .idea
 *.iml
+dist
+build
+*.egg-info
+venv

--- a/example/docs/index.md
+++ b/example/docs/index.md
@@ -3,3 +3,7 @@
 below you should see diagram:
 
 ![test diagram](test.drawio)
+
+```bash
+![test diagram](test.drawio)
+```

--- a/example/mkdocs.yml
+++ b/example/mkdocs.yml
@@ -6,10 +6,6 @@ nav:
   - test: 'index.md'
   - test2: 'test/test2.md'
   
-
-theme:
-  name: material
-    
 plugins:
     - search
     - drawio_file

--- a/mkdocs_drawio_file/__init__.py
+++ b/mkdocs_drawio_file/__init__.py
@@ -1,3 +1,3 @@
-from .plugin import drawio_file_plugin
+from .plugin import DrawioFilePlugin
 
-__all__ = [drawio_file_plugin]
+__all__ = [DrawioFilePlugin]

--- a/mkdocs_drawio_file/plugin.py
+++ b/mkdocs_drawio_file/plugin.py
@@ -41,6 +41,9 @@ class DrawioFilePlugin(BasePlugin):
         return str_xml
 
     def substitute_image(self, path, src: str):
+        if src.startswith("../"):
+            src = src[3:]
+
         file_name = os.path.join(path, src)
 
         with open(file_name, 'r') as q_data:

--- a/mkdocs_drawio_file/plugin.py
+++ b/mkdocs_drawio_file/plugin.py
@@ -1,22 +1,25 @@
-
 import os
-import logging
-import mkdocs
-import mkdocs.plugins
-from mkdocs.structure.files import File
-from mkdocs.structure.files import get_files
 import re
 import string
+import logging
+import mkdocs
+from mkdocs.plugins import BasePlugin
 
 
-# This global is a hack to keep track of the last time the plugin rendered diagrams.
-# A global is required because plugins are reinitialized each time a change is detected.
-last_run_timestamp = 0
+# ------------------------
+# Constants and utilities
+# ------------------------
+RE_PATTERN = r'!\[(.*?)\]\((.*?.drawio)\)'
+SUB_TEMPLATE = string.Template(
+        "<div class=\"mxgraph\" style=\"max-width:100%;border:1px solid transparent;\" data-mxgraph=\"{&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;resize&quot;:true,&quot;toolbar&quot;:&quot;zoom layers tags lightbox&quot;,&quot;edit&quot;:&quot;_blank&quot;,&quot;xml&quot;:&quot;$xml_drawio&quot;}\"></div>")
 
-    
-
-    
-class drawio_file_plugin(mkdocs.plugins.BasePlugin):
+# ------------------------
+# Plugin
+# ------------------------
+class DrawioFilePlugin(BasePlugin):
+    """
+    Plugin for embedding DrawIO Diagrams into your Docs
+    """
     config_scheme = (
         (
             "file_extension",
@@ -24,15 +27,11 @@ class drawio_file_plugin(mkdocs.plugins.BasePlugin):
         ),
     )
 
-    TEMPLATE = string.Template("<div class=\"mxgraph\" style=\"max-width:100%;border:1px solid transparent;\" data-mxgraph=\"{&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;resize&quot;:true,&quot;toolbar&quot;:&quot;zoom layers tags lightbox&quot;,&quot;edit&quot;:&quot;_blank&quot;,&quot;xml&quot;:&quot;$xml_drawio&quot;}\"></div>")
-
     def __init__(self):
         self.log = logging.getLogger("mkdocs.plugins.diagrams")
         self.pool = None
 
-
-
-    def escape( str_xml: str ):
+    def escape(self, str_xml: str):
         str_xml = str_xml.replace("&", "&amp;")
         str_xml = str_xml.replace("<", "&lt;")
         str_xml = str_xml.replace(">", "&gt;")
@@ -40,29 +39,25 @@ class drawio_file_plugin(mkdocs.plugins.BasePlugin):
         str_xml = str_xml.replace("'", "&apos;")
         return str_xml
 
-    def conver_file( file_name: str):
+    def substitute_file(self, file_name: str):
         with open(file_name, 'r') as q_data:
             q_lines = q_data.readlines()
 
-        drawio_text = ''.join([ item.strip() for item in q_lines])
+        drawio_text = ''.join([item.strip() for item in q_lines])
+        drawio_text_ecaped = self.escape(drawio_text)
 
-        drawio_text_ecaped = drawio_file_plugin.escape(drawio_text)
+        return SUB_TEMPLATE.substitute(xml_drawio=drawio_text_ecaped)
 
-        drawio_html = drawio_file_plugin.TEMPLATE.substitute(xml_drawio = drawio_text_ecaped )
-        return drawio_html
-
-    def convert_match(match,config,path):
+    def substitute_files(self, match, path):
         file_tag = match.group()
         file_name = file_tag[file_tag.find("(")+1:file_tag.find(")")]
-        converted = drawio_file_plugin.conver_file(os.path.join(path,file_name ))
-        return converted 
 
-    def on_page_markdown(self, markdown, page,files,config) -> str:
-        def file_sub(match):
-            return drawio_file_plugin.convert_match(match,config,os.path.dirname(page.file.abs_src_path))
+        return self.substitute_file(os.path.join(path, file_name))
 
-        pattern = re.compile(r'!\[(.*?)\]\((.*?.drawio)\)', flags=re.IGNORECASE)
-        
-        markdown = pattern.sub( file_sub, markdown)    
-        markdown = markdown + "<script type=\"text/javascript\" src=\"https://viewer.diagrams.net/js/viewer-static.min.js\"></script>"
-        return markdown
+    def on_page_markdown(self, markdown, page, files, config) -> str:
+        def substitution(match):
+            return self.substitute_files(match, os.path.dirname(page.file.abs_src_path))
+
+        pattern = re.compile(RE_PATTERN, flags=re.IGNORECASE)
+
+        return pattern.sub(substitution, markdown) + "<script type=\"text/javascript\" src=\"https://viewer.diagrams.net/js/viewer-static.min.js\"></script>"

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 from setuptools import setup, find_packages
 import os.path
 
+
 def read(name):
     mydir = os.path.abspath(os.path.dirname(__file__))
     return open(os.path.join(mydir, name)).read()
 
 
-setuptools.setup(
+setup(
     name="mkdocs-drawio-file",
     version="1.3.0",
     packages=find_packages(),
@@ -18,7 +19,8 @@ setuptools.setup(
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
     install_requires=["mkdocs"],
-    entry_points={"mkdocs.plugins": ["drawio_file = mkdocs_drawio_file:drawio_file_plugin",]},
+    entry_points={"mkdocs.plugins": [
+        "drawio_file = mkdocs_drawio_file:DrawioFilePlugin",]},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(name):
 
 setup(
     name="mkdocs-drawio-file",
-    version="1.3.0",
+    version="1.4.0",
     packages=find_packages(),
     url="https://github.com/onixpro/mkdocs-drawio-file",
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     description="MkDocs plugin to embed drawio files",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
-    install_requires=["mkdocs"],
+    install_requires=["mkdocs","beautifulsoup4"],
     entry_points={"mkdocs.plugins": [
         "drawio_file = mkdocs_drawio_file:DrawioFilePlugin",]},
     classifiers=[


### PR DESCRIPTION
# Description
This PR changes the complete processing of this plugin from markdown parsing to HTML parsing by using `BeautifulSoup` and instead of looking up the drawio extension by regex it uses the parsed HTML to search for generated `img` tags containing a src ending with `.drawio`.

## Motivation
With the current implementation the Markdown of every page is parsed without any logic regarding code blocks or any other structures.

Therefore if you want to demonstrate how this plugin works in your own documentation any image references containing the drawio extension will be replaced by the HTML tag regardless of the context. 

For example a Markdown page like the following:

```markdown
# How to use drawio file
\```markdown
\![demo](demo.drawio)
\```
```

Will be replaced by:

```markdown
# How to use drawio file
\```markdown
<div class="geDiagramContainer" data-mxgraph="..." style="max-width: 100%; border: 1px solid transparent; position: relative; touch-action: none; cursor: pointer; overflow: hidden; margin-top: 26px; width: 375px; height: 105px;"></div>
\```
```

## Notice
Furthermore, the project files have been properly formatted and standard python naming conventions and settings have been enforced.

## Resolves
This PR will resolve https://github.com/onixpro/mkdocs-drawio-file/issues/1