### PR TITLE
add support for multi page diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,36 @@
-# Embedding files of Diagrams.net (Draw.io) into MkDocs
-
+# MkDocs Plugin for embedding Diagrams.net (Draw.io)
 [![](https://github.com/onixpro/mkdocs-drawio-file/workflows/Deploy/badge.svg)](https://github.com/onixpro/mkdocs-drawio-file/actions)
 [![PyPI](https://img.shields.io/pypi/v/mkdocs-drawio-file)](https://pypi.org/project/mkdocs-drawio-file/)
-
-
 
 [Buy me a 🍜](https://www.buymeacoffee.com/SergeyLukin)
 
 ## Features
-
-With the plugin configured, you can now proceed to embed images by simply embedding the `*.drawio` diagram file as you would with any image file:
+This plugin enables you to embed interactive drawio diagrams in your documentation. Simple add your files like you would for any other image type:
 
 ```markdown
-![My alt text](my-diagram.drawio)
+![](my-diagram.drawio)
 ```
 
+Additionally this plugin supports multi page diagrams by using the `alt` text:
 
-## Dependencies
+```markdown
+![Page-2](my-diagram.drawio)
+```
 
 ## Setup
-
 Install plugin using pip:
 
 ```
 pip install mkdocs-drawio-file
 ```
 
-Next, add the plugin to your `mkdocs.yml`
+Add the plugin to your `mkdocs.yml`
 
 ```yaml
 plugins:
   - drawio_file
 ```
+
+## How it works
+
+After your mkdocs has generated the HTML for your documentation, the plugin adds the necessary diagram.net javascript library. Searches for `img` tags with a file ending of `*.drawio` and replaces them with the appropiate `mxgraph` html block. For further details, please look at the [official diagrams.net documentation](https://www.diagrams.net/doc/faq/embed-html).

--- a/example/docs/index.md
+++ b/example/docs/index.md
@@ -1,8 +1,10 @@
 # Test of draw.io
 
 below you should see diagram:
-
 ![test diagram](test.drawio)
+
+below you should see diagram Page-2:
+![Page-2](test.drawio)
 
 ```bash
 ![test diagram](test.drawio)

--- a/example/docs/index.md
+++ b/example/docs/index.md
@@ -1,6 +1,6 @@
 # Test of draw.io
 
-below you should see diagram:
+below you should see diagram Page-1 (default):
 ![test diagram](test.drawio)
 
 below you should see diagram Page-2:

--- a/example/docs/test.drawio
+++ b/example/docs/test.drawio
@@ -1,6 +1,6 @@
 <mxfile host="65bd71144e">
     <diagram id="sWgCjdYztQFh1ezxrF-R" name="Page-1">
-        <mxGraphModel dx="949" dy="439" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+        <mxGraphModel dx="1492" dy="379" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
@@ -15,6 +15,37 @@
                 </mxCell>
                 <mxCell id="4" value="c" style="ellipse;whiteSpace=wrap;html=1;" parent="1" vertex="1">
                     <mxGeometry x="310" y="60" width="120" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="jEQN0c8lupLUuRs0BYHV-4" value="Page-1" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="210" y="30" width="60" height="30" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+    <diagram id="wlfak2Qh67BLjky1jg1P" name="Page-2">
+        <mxGraphModel dx="1492" dy="379" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="Xq97M8SX7CFenNwQ6utj-5" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="Xq97M8SX7CFenNwQ6utj-1" target="Xq97M8SX7CFenNwQ6utj-6">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="220" y="200" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="Xq97M8SX7CFenNwQ6utj-1" value="a" style="whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="1">
+                    <mxGeometry x="80" y="60" width="80" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="Xq97M8SX7CFenNwQ6utj-3" value="c" style="ellipse;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                    <mxGeometry x="310" y="60" width="120" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="Xq97M8SX7CFenNwQ6utj-4" value="Page-2" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="210" y="30" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="Xq97M8SX7CFenNwQ6utj-7" value="" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="1" source="Xq97M8SX7CFenNwQ6utj-6" target="Xq97M8SX7CFenNwQ6utj-3">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="Xq97M8SX7CFenNwQ6utj-6" value="b" style="rhombus;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                    <mxGeometry x="200" y="60" width="80" height="80" as="geometry"/>
                 </mxCell>
             </root>
         </mxGraphModel>

--- a/example/docs/test/test2.md
+++ b/example/docs/test/test2.md
@@ -1,3 +1,3 @@
 # test
 
-![test diagram2](test.drawio)
+![](test.drawio)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mkdocs-drawio-file"
-version = "1.3.0"
+version = "1.5.0"
 description = "Mkdocs plugin that renders .drawio files"
 authors = ["Sergey Lukin <onixpro@gmail.com>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(name):
 
 setup(
     name="mkdocs-drawio-file",
-    version="1.4.0",
+    version="1.5.0",
     packages=find_packages(),
     url="https://github.com/onixpro/mkdocs-drawio-file",
     license="MIT",
@@ -18,7 +18,7 @@ setup(
     description="MkDocs plugin to embed drawio files",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
-    install_requires=["mkdocs","beautifulsoup4"],
+    install_requires=["mkdocs","beautifulsoup4","lxml"],
     entry_points={"mkdocs.plugins": [
         "drawio_file = mkdocs_drawio_file:DrawioFilePlugin",]},
     classifiers=[


### PR DESCRIPTION
# Motivation
Add support for multi page diagrams

## Description
This PR add the functionality to select a specific diagram page via the `alt` attribute:

E.g. the following would select pages `Page-2` or `Architecture` of the diagram

```markdown
![Page-2](your-diagram.drawio)
![Architecture](your-diagram.drawio)
```

If no page with a given name exists the default behaviour is to show / render the first page.
E.g. the following two examples would both render the first page:
```markdown
![](your-diagram.drawio)
![doesn't exist](your-diagram.drawio)
```

## How it works
This PR adds the lxml python library to parse the files not as strings but xml objects and filter for the `name` attribute of the contained `diagram` tags.