### PR TITLE
fix: fileending regex parsing

### DIFF
--- a/mkdocs_drawio_file/plugin.py
+++ b/mkdocs_drawio_file/plugin.py
@@ -11,9 +11,8 @@ from mkdocs.plugins import BasePlugin
 # ------------------------
 # Constants and utilities
 # ------------------------
-RE_PATTERN = r'!\[(.*?)\]\((.*?.drawio)\)'
 SUB_TEMPLATE = string.Template(
-        "<div class=\"mxgraph\" style=\"max-width:100%;border:1px solid transparent;\" data-mxgraph=\"{&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;resize&quot;:true,&quot;toolbar&quot;:&quot;zoom layers tags lightbox&quot;,&quot;edit&quot;:&quot;_blank&quot;,&quot;xml&quot;:&quot;$xml_drawio&quot;}\"></div>")
+    "<div class=\"mxgraph\" style=\"max-width:100%;border:1px solid transparent;\" data-mxgraph=\"{&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;resize&quot;:true,&quot;toolbar&quot;:&quot;zoom layers tags lightbox&quot;,&quot;edit&quot;:&quot;_blank&quot;,&quot;xml&quot;:&quot;$xml_drawio&quot;}\"></div>")
 
 # ------------------------
 # Plugin
@@ -41,7 +40,7 @@ class DrawioFilePlugin(BasePlugin):
         soup = BeautifulSoup(output_content, 'html.parser')
 
         # search for images using drawio extension
-        diagrams = soup.findAll('img', src=re.compile(r'.*\.drawio', re.IGNORECASE))
+        diagrams = soup.findAll('img', src=re.compile(r'.*\.drawio$', re.IGNORECASE))
         if len(diagrams) == 0:
             return output_content
 
@@ -66,7 +65,7 @@ class DrawioFilePlugin(BasePlugin):
         escaped_xml = self.escape_diagram(diagram)
 
         return SUB_TEMPLATE.substitute(xml_drawio=escaped_xml)
-    
+
     def parse_diagram(self, data, alt):
         if alt == None:
             return etree.tostring(data, encoding=str)
@@ -87,7 +86,7 @@ class DrawioFilePlugin(BasePlugin):
                 print(f"Warning: Found {len(page)} results for page name '{alt}'")
         except e:
             print(f"Error: Could not properly parse page name: '{alt}'")
-        
+
         return etree.tostring(mxfile, encoding=str)
 
     def escape_diagram(self, str_xml: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mkdocs-drawio-file"
-version = "1.5.2"
+version = "1.5.3"
 description = "Mkdocs plugin that renders .drawio files"
 authors = ["Sergey Lukin <onixpro@gmail.com>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(name):
 
 setup(
     name="mkdocs-drawio-file",
-    version="1.5.2",
+    version="1.5.3",
     packages=find_packages(),
     url="https://github.com/onixpro/mkdocs-drawio-file",
     license="MIT",
@@ -18,7 +18,7 @@ setup(
     description="MkDocs plugin to embed drawio files",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
-    install_requires=["mkdocs","beautifulsoup4","lxml"],
+    install_requires=["mkdocs", "beautifulsoup4", "lxml"],
     entry_points={"mkdocs.plugins": [
         "drawio_file = mkdocs_drawio_file:DrawioFilePlugin",]},
     classifiers=[


### PR DESCRIPTION
This PR should fix https://github.com/onixpro/mkdocs-drawio-file/issues/7 by parsing only the end of the filename and not consider any filename that contains drawio.

Some minor formatting was done as well but the main change is in line 46 of the plugin.py.
https://github.com/onixpro/mkdocs-drawio-file/pull/8/files#diff-23110d9c622718e349749468370d98bd60ca90b88e13b94081724724de934152R45-R46